### PR TITLE
[Bug] Handle empty output from fastp

### DIFF
--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -850,7 +850,14 @@ void Stats::reportHtmlContents(ofstream& ofs, string filteringType, string readN
         } else {
             count = mBaseContents['G' & 0x07] + mBaseContents['C' & 0x07] ;
         }
-        string percentage = to_string((double)count * 100.0 / mBases);
+
+        string percentage;
+        if (mBases != 0) {
+            percentage = to_string((double)count * 100.0 / mBases);
+        } else {
+            percentage = "-nan";
+        }
+
         if(percentage.length()>5)
             percentage = percentage.substr(0,5);
         string name = base + "(" + percentage + "%)"; 


### PR DESCRIPTION
* If fastp filters out all reads the output file does not have any bases. This leads to a division by zero error which causes a segfault in the HTML generation code